### PR TITLE
gateway: drop fastd pkg overlay

### DIFF
--- a/gateway.nix
+++ b/gateway.nix
@@ -610,18 +610,6 @@ in
     (name: domain: domain.fastd.port)
     (lib.filterAttrs (_: domain: domain.fastd.enable) enabledDomains);
 
-    nixpkgs.overlays = [(self: super: {
-      fastd = super.fastd.overrideAttrs (oldAttrs: {
-        version = "23";
-        src = pkgs.fetchFromGitHub {
-          owner  = "neocturne";
-          repo = "fastd";
-          rev = "v23";
-          sha256 = "sha256-Sz6VEjKziL/w2a4VWFfMPDYvm7UZh5A/NmzP10rJ2r8=";
-        };
-      });
-    })];
-
     services.fastd-exporter = lib.mkIf hasEnabledFastdDomain {
       enable = true;
       instances = lib.mapAttrs (name: domain: config.services.fastd.${name}.statusSocket) enabledDomains;


### PR DESCRIPTION
With fastd v23 beeing released and available via nixpkgs we no longer need our local overlay.

https://github.com/NixOS/nixpkgs/pull/376992

---

Only merge once the v23 bump has reached nixos-24.11: https://nixpk.gs/pr-tracker.html?pr=376992